### PR TITLE
新增图片全屏浏览与快捷切换功能

### DIFF
--- a/dashapp/assets/image_viewer.js
+++ b/dashapp/assets/image_viewer.js
@@ -1,0 +1,162 @@
+(function () {
+    "use strict";
+
+    if (window.__imageViewerInitialized) {
+        return;
+    }
+    window.__imageViewerInitialized = true;
+
+    var viewerState = {
+        links: [],
+        index: -1,
+        previousFocus: null
+    };
+
+    function getViewerElements() {
+        return {
+            viewer: document.getElementById("image_viewer"),
+            image: document.getElementById("image_viewer_image"),
+            previous: document.getElementById("image_viewer_previous"),
+            next: document.getElementById("image_viewer_next")
+        };
+    }
+
+    function isVisibleImageLink(link) {
+        var image = link.querySelector("img");
+        if (!image) {
+            return false;
+        }
+
+        var style = window.getComputedStyle(image);
+        return style.display !== "none"
+            && style.visibility !== "hidden"
+            && image.getClientRects().length > 0;
+    }
+
+    function collectVisibleImageLinks() {
+        return Array.prototype.filter.call(
+            document.querySelectorAll("#container a.image-viewer-link"),
+            isVisibleImageLink
+        );
+    }
+
+    function renderCurrentImage() {
+        var elements = getViewerElements();
+        var link = viewerState.links[viewerState.index];
+        if (!elements.viewer || !elements.image || !elements.previous || !elements.next || !link) {
+            return;
+        }
+
+        var sourceImage = link.querySelector("img");
+        elements.image.src = link.href;
+        elements.image.alt = sourceImage ? sourceImage.alt : "";
+
+        var atFirstImage = viewerState.index === 0;
+        var atLastImage = viewerState.index === viewerState.links.length - 1;
+        elements.previous.disabled = atFirstImage;
+        elements.next.disabled = atLastImage;
+        elements.previous.classList.toggle("is-unavailable", atFirstImage);
+        elements.next.classList.toggle("is-unavailable", atLastImage);
+    }
+
+    function openViewer(link) {
+        var elements = getViewerElements();
+        if (!elements.viewer || !elements.image) {
+            return;
+        }
+
+        viewerState.links = collectVisibleImageLinks();
+        viewerState.index = viewerState.links.indexOf(link);
+        if (viewerState.index < 0) {
+            return;
+        }
+
+        viewerState.previousFocus = document.activeElement;
+        elements.viewer.classList.add("is-open");
+        elements.viewer.setAttribute("aria-hidden", "false");
+        document.body.classList.add("image-viewer-open");
+        renderCurrentImage();
+    }
+
+    function closeViewer() {
+        var elements = getViewerElements();
+        if (!elements.viewer || !elements.viewer.classList.contains("is-open")) {
+            return;
+        }
+
+        elements.viewer.classList.remove("is-open");
+        elements.viewer.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("image-viewer-open");
+        elements.image.removeAttribute("src");
+
+        if (viewerState.previousFocus && typeof viewerState.previousFocus.focus === "function") {
+            viewerState.previousFocus.focus();
+        }
+        viewerState.links = [];
+        viewerState.index = -1;
+        viewerState.previousFocus = null;
+    }
+
+    function moveViewer(direction) {
+        var nextIndex = viewerState.index + direction;
+        if (nextIndex < 0 || nextIndex >= viewerState.links.length) {
+            return;
+        }
+
+        viewerState.index = nextIndex;
+        renderCurrentImage();
+    }
+
+    function isViewerOpen() {
+        var viewer = document.getElementById("image_viewer");
+        return Boolean(viewer && viewer.classList.contains("is-open"));
+    }
+
+    document.addEventListener("click", function (event) {
+        var closeButton = event.target.closest("#image_viewer_close");
+        if (closeButton) {
+            event.preventDefault();
+            closeViewer();
+            return;
+        }
+
+        var previousButton = event.target.closest("#image_viewer_previous");
+        if (previousButton) {
+            event.preventDefault();
+            moveViewer(-1);
+            return;
+        }
+
+        var nextButton = event.target.closest("#image_viewer_next");
+        if (nextButton) {
+            event.preventDefault();
+            moveViewer(1);
+            return;
+        }
+
+        var link = event.target.closest("#container a.image-viewer-link");
+        if (!link || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+            return;
+        }
+
+        event.preventDefault();
+        openViewer(link);
+    });
+
+    document.addEventListener("keydown", function (event) {
+        if (!isViewerOpen()) {
+            return;
+        }
+
+        if (event.key === "Escape") {
+            event.preventDefault();
+            closeViewer();
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+            event.preventDefault();
+            moveViewer(-1);
+        } else if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+            event.preventDefault();
+            moveViewer(1);
+        }
+    });
+})();

--- a/dashapp/assets/style.css
+++ b/dashapp/assets/style.css
@@ -173,3 +173,122 @@ button:hover {
 #slider1 .rc-slider-dot:last-child {
     border-color: #FFA500;
 }
+
+body.image-viewer-open {
+    overflow: hidden;
+}
+
+#image_viewer {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: none;
+    width: 100vw;
+    height: 100vh;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    background: rgba(0, 0, 0, 0.9);
+}
+
+#image_viewer.is-open {
+    display: block;
+}
+
+#image_viewer_image {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100vw;
+    height: 100vh;
+    max-width: none;
+    max-height: none;
+    margin: 0;
+    padding: 0;
+    object-fit: contain;
+    user-select: none;
+}
+
+.image-viewer-zone {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    z-index: 1;
+    display: flex;
+    width: clamp(96px, 15vw, 220px);
+    align-items: center;
+}
+
+.image-viewer-zone--previous {
+    left: 0;
+    justify-content: flex-start;
+}
+
+.image-viewer-zone--next {
+    right: 0;
+    justify-content: flex-end;
+}
+
+#image_viewer .image-viewer-control {
+    all: unset;
+    box-sizing: border-box;
+    position: absolute;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0;
+    color: rgba(255, 255, 255, 0.9);
+    background: rgba(0, 0, 0, 0.42);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    user-select: none;
+    transition: opacity 0.16s ease, background-color 0.16s ease;
+}
+
+#image_viewer .image-viewer-control--previous,
+#image_viewer .image-viewer-control--next {
+    top: 50%;
+    width: 58px;
+    height: 96px;
+    font-size: 52px;
+    line-height: 1;
+    transform: translateY(-50%);
+}
+
+#image_viewer .image-viewer-control--previous {
+    left: 12px;
+    border-radius: 0 8px 8px 0;
+}
+
+#image_viewer .image-viewer-control--next {
+    right: 12px;
+    border-radius: 8px 0 0 8px;
+}
+
+#image_viewer .image-viewer-control--close {
+    top: 12px;
+    right: 12px;
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    font-size: 42px;
+    line-height: 1;
+}
+
+.image-viewer-zone:hover .image-viewer-control:not(.is-unavailable) {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+#image_viewer .image-viewer-control:hover {
+    color: white;
+    background: rgba(0, 0, 0, 0.68);
+    border: 1px solid rgba(255, 255, 255, 0.38);
+}
+
+#image_viewer .image-viewer-control.is-unavailable {
+    opacity: 0;
+    pointer-events: none;
+}

--- a/dashapp/assets/style.css
+++ b/dashapp/assets/style.css
@@ -250,34 +250,80 @@ body.image-viewer-open {
 #image_viewer .image-viewer-control--previous,
 #image_viewer .image-viewer-control--next {
     top: 50%;
-    width: 58px;
-    height: 96px;
-    font-size: 52px;
-    line-height: 1;
+    width: 76px;
+    height: 76px;
+    border-radius: 50%;
+    color: rgba(255, 255, 255, 0.92);
+    background: rgba(86, 86, 86, 0.58);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(4px);
+    font-size: 0;
+    line-height: 0;
     transform: translateY(-50%);
+    transition: opacity 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, transform 0.16s ease,
+        box-shadow 0.16s ease;
 }
 
 #image_viewer .image-viewer-control--previous {
-    left: 12px;
-    border-radius: 0 8px 8px 0;
+    left: 18px;
+    padding: 0;
 }
 
 #image_viewer .image-viewer-control--next {
-    right: 12px;
-    border-radius: 8px 0 0 8px;
+    right: 18px;
+    padding: 0;
+}
+
+#image_viewer .image-viewer-control--previous::before,
+#image_viewer .image-viewer-control--next::before {
+    content: "";
+    display: block;
+    width: 28px;
+    height: 36px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 40'%3E%3Cpath d='M9.5 5L22.5 20L9.5 35' fill='none' stroke='white' stroke-opacity='.92' stroke-width='4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    filter: drop-shadow(0 0 0 rgba(255, 255, 255, 0));
+    transition: transform 0.1s ease, filter 0.16s ease;
+}
+
+#image_viewer .image-viewer-control--previous::before {
+    transform: scaleX(-1);
 }
 
 #image_viewer .image-viewer-control--close {
-    top: 12px;
-    right: 12px;
-    width: 52px;
-    height: 52px;
+    top: 16px;
+    right: 18px;
+    width: 56px;
+    height: 56px;
     border-radius: 50%;
-    font-size: 42px;
-    line-height: 1;
+    color: rgba(255, 255, 255, 0.92);
+    background: rgba(86, 86, 86, 0.58);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.24);
+    backdrop-filter: blur(4px);
+    font-size: 0;
+    line-height: 0;
+    transition: opacity 0.16s ease, background-color 0.16s ease, border-color 0.16s ease, transform 0.16s ease,
+        box-shadow 0.16s ease;
 }
 
-.image-viewer-zone:hover .image-viewer-control:not(.is-unavailable) {
+#image_viewer .image-viewer-control--close::before {
+    content: "";
+    display: block;
+    width: 24px;
+    height: 24px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Cpath d='M7 7L25 25M25 7L7 25' fill='none' stroke='white' stroke-opacity='.92' stroke-width='3.5' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+    filter: drop-shadow(0 0 0 rgba(255, 255, 255, 0));
+    transition: filter 0.16s ease;
+}
+
+#image_viewer .image-viewer-zone:hover .image-viewer-control:not(.is-unavailable) {
     opacity: 1;
     pointer-events: auto;
 }
@@ -286,6 +332,57 @@ body.image-viewer-open {
     color: white;
     background: rgba(0, 0, 0, 0.68);
     border: 1px solid rgba(255, 255, 255, 0.38);
+}
+
+#image_viewer .image-viewer-control--previous:hover,
+#image_viewer .image-viewer-control--next:hover {
+    background: rgba(104, 104, 104, 0.78);
+    border-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1), 0 0 26px rgba(255, 255, 255, 0.22),
+        0 10px 30px rgba(0, 0, 0, 0.34);
+    transform: translateY(-50%) scale(1.06);
+}
+
+#image_viewer .image-viewer-control--previous:hover::before,
+#image_viewer .image-viewer-control--next:hover::before {
+    filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.48));
+}
+
+#image_viewer .image-viewer-control--previous:active,
+#image_viewer .image-viewer-control--next:active {
+    background: rgba(116, 116, 116, 0.84);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.14), 0 0 14px rgba(255, 255, 255, 0.2),
+        0 4px 14px rgba(0, 0, 0, 0.28);
+    transform: translateY(-50%) scale(0.92);
+    transition-duration: 0.08s;
+}
+
+#image_viewer .image-viewer-control--previous:active::before {
+    transform: translateX(-2px) scaleX(-1);
+}
+
+#image_viewer .image-viewer-control--next:active::before {
+    transform: translateX(2px);
+}
+
+#image_viewer .image-viewer-control--close:hover {
+    background: rgba(104, 104, 104, 0.78);
+    border-color: rgba(255, 255, 255, 0.2);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1), 0 0 24px rgba(255, 255, 255, 0.2),
+        0 8px 26px rgba(0, 0, 0, 0.32);
+    transform: scale(1.06);
+}
+
+#image_viewer .image-viewer-control--close:hover::before {
+    filter: drop-shadow(0 0 5px rgba(255, 255, 255, 0.46));
+}
+
+#image_viewer .image-viewer-control--close:active {
+    background: rgba(116, 116, 116, 0.84);
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.14), 0 0 12px rgba(255, 255, 255, 0.18),
+        0 3px 12px rgba(0, 0, 0, 0.26);
+    transform: scale(0.9);
+    transition-duration: 0.08s;
 }
 
 #image_viewer .image-viewer-control.is-unavailable {

--- a/dashapp/image.py
+++ b/dashapp/image.py
@@ -297,6 +297,46 @@ app.layout = html.Div(
         ),
         html.Div(
             [
+                html.Img(id="image_viewer_image", alt="", draggable="false"),
+                html.Div(
+                    html.Button(
+                        "\u276e",
+                        id="image_viewer_previous",
+                        className="image-viewer-control image-viewer-control--previous",
+                        type="button",
+                        **{"aria-label": "上一张"},
+                    ),
+                    id="image_viewer_previous_zone",
+                    className="image-viewer-zone image-viewer-zone--previous",
+                ),
+                html.Div(
+                    [
+                        html.Button(
+                            "\u00d7",
+                            id="image_viewer_close",
+                            className="image-viewer-control image-viewer-control--close",
+                            type="button",
+                            **{"aria-label": "关闭"},
+                        ),
+                        html.Button(
+                            "\u276f",
+                            id="image_viewer_next",
+                            className="image-viewer-control image-viewer-control--next",
+                            type="button",
+                            **{"aria-label": "下一张"},
+                        ),
+                    ],
+                    id="image_viewer_next_zone",
+                    className="image-viewer-zone image-viewer-zone--next",
+                ),
+            ],
+            id="image_viewer",
+            className="image-viewer",
+            role="dialog",
+            **{"aria-hidden": "true", "aria-modal": "true"},
+        ),
+        html.Div(
+            [
                 html.Div(
                     html.Div(
                         [
@@ -450,6 +490,7 @@ def popup_100_pics(n_clicks):
                 if img_path.endswith(".webp") and not is_remote(img_path)
                 else img_path,
                 target="_blank",
+                className="image-viewer-link",
             )
         )
         browsed_img_list.append(img_path)

--- a/dashapp/image.py
+++ b/dashapp/image.py
@@ -300,7 +300,7 @@ app.layout = html.Div(
                 html.Img(id="image_viewer_image", alt="", draggable="false"),
                 html.Div(
                     html.Button(
-                        "\u276e",
+                        "\u2039",
                         id="image_viewer_previous",
                         className="image-viewer-control image-viewer-control--previous",
                         type="button",
@@ -319,7 +319,7 @@ app.layout = html.Div(
                             **{"aria-label": "关闭"},
                         ),
                         html.Button(
-                            "\u276f",
+                            "\u203a",
                             id="image_viewer_next",
                             className="image-viewer-control image-viewer-control--next",
                             type="button",


### PR DESCRIPTION
## 主要变更

- 点击图片后在当前页面打开无间距全屏遮罩，图片保持比例并最大化显示
- 支持键盘左右键和上下键切换，首尾停止，支持 ESC 关闭
- 在左右感应区显示半透明切换按钮，右侧感应区同时显示关闭按钮
- 保留鼠标中键及修饰键在新标签页打开图片的原有行为
- 优化圆形箭头与关闭按钮的居中、悬浮光晕和点击反馈

## 验证

- Python AST 语法检查通过
- `node --check dashapp/assets/image_viewer.js` 通过
- `git diff --check` 通过
- 浏览器实测左右键、上下键、首尾停止、ESC 关闭及滚动锁定正常
- 页面控制台无错误
- 与最新 `origin/master` 执行三方合并检查，无冲突